### PR TITLE
[feature] `CatalogSource` doesn't need anonymous proxy anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ ADD nfs-subdir-external-provisioner-olm.yaml wordpress-operator-olm.yaml .
 
 COPY make-catalog.py .
 
+COPY pullSecret/.dockerconfigjson /root/.docker/configs.json
+RUN pwd; ls -la /root/.docker/
+
 ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" /tmp/cachebuster
 RUN python3 make-catalog.py --configs-out=/configs --cache-out=/tmp/cache *-olm.yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ADD nfs-subdir-external-provisioner-olm.yaml wordpress-operator-olm.yaml .
 
 COPY make-catalog.py .
 
-COPY pullSecret/.dockerconfigjson /root/.docker/configs.json
+COPY pullSecret/.dockerconfigjson /root/.docker/config.json
 RUN pwd; ls -la /root/.docker/
 
 ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" /tmp/cachebuster

--- a/catalogSource.yml
+++ b/catalogSource.yml
@@ -1,5 +1,6 @@
 ---
 # https://docs.openshift.com/dedicated/operators/admin/olm-managing-custom-catalogs.html#olm-creating-catalog-from-index_olm-managing-custom-catalogs
+# This yaml is now applied by ansible in OKD or via ticket in OS4
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -17,7 +18,9 @@ spec:
       catalogDir: /configs
   # anonymous.apps.t-ocp-its-01.xaas.epfl.ch is a (temporary, from the `.t-` part)
   # mirroring proxy of quay-its.epfl.ch; see https://go.epfl.ch/INC0674050
-  image: anonymous.apps.t-ocp-its-01.xaas.epfl.ch/svc0041/isas-fsd-catalog:latest
+  image: quay-its.epfl.ch/svc0041/isas-fsd-catalog:latest
+  secrets:
+    - svc0041-svc0041-puller-pull-secret
   resources:
     limits:
       memory: 256Mi

--- a/make-catalog.py
+++ b/make-catalog.py
@@ -304,15 +304,11 @@ class BundleVersion:
     @classmethod
     def _do_load (cls, logger, docker_image_name, expected_version):
         try:
-            # with open("/var/run/secrets/openshift.io/build/pullSecret", "r") as f:
-            #     content = f.read()
-            # print(content)
-            files = os.listdir("/var/run/secrets/openshift.io/build/pullSecret")
-            print(files)
             opm_rendered = run_opm(
-                ["render", docker_image_name, "--output=yaml"], # , "--authfile", ""
+                ["render", docker_image_name, "--output=yaml"],
                 logger=logger, capture_output=True)
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
+            logger.warning(e.output.decode())
             return None
 
         yamls = list(r[1] for r in split_yaml_documents(opm_rendered.stdout))

--- a/make-catalog.py
+++ b/make-catalog.py
@@ -304,8 +304,13 @@ class BundleVersion:
     @classmethod
     def _do_load (cls, logger, docker_image_name, expected_version):
         try:
+            # with open("/var/run/secrets/openshift.io/build/pullSecret", "r") as f:
+            #     content = f.read()
+            # print(content)
+            files = os.listdir("/var/run/secrets/openshift.io/build/pullSecret")
+            print(files)
             opm_rendered = run_opm(
-                ["render", docker_image_name, "--output=yaml"],
+                ["render", docker_image_name, "--output=yaml"], # , "--authfile", ""
                 logger=logger, capture_output=True)
         except subprocess.CalledProcessError:
             return None

--- a/make-catalog.py
+++ b/make-catalog.py
@@ -97,7 +97,7 @@ def run_opm (cmdline_args, *args, **kwargs):
         logger = kwargs.pop("logger")
         logger.info("Running " + " ".join(cmdline))
 
-    return subprocess.run(cmdline, *args, **kwargs)
+    return subprocess.run(cmdline, *args, text=True, **kwargs)
 
 class CataloggerLogger:
     def __init__ (self):
@@ -292,9 +292,7 @@ class BundleVersion:
 
     @classmethod
     def load (cls, logger, docker_image_name, expected_version):
-        logger.info(f'IMAGE NAME------------------{docker_image_name}')
         if docker_image_name not in cls._load_cache:
-            logger.info(f'IMAGE NOT IN CACHE------------------{docker_image_name}')
             cls._load_cache[docker_image_name] = cls._do_load(
                 logger, docker_image_name, expected_version)
         return cls._load_cache[docker_image_name]
@@ -306,13 +304,10 @@ class BundleVersion:
     @classmethod
     def _do_load (cls, logger, docker_image_name, expected_version):
         try:
-            logger.info(f'BEFORE RUN OPM------------------{docker_image_name}')
             opm_rendered = run_opm(
                 ["render", docker_image_name, "--output=yaml"],
-                logger=logger, capture_output=True)
-        except subprocess.CalledProcessError as e:
-            logger.info(f'OPM EXCEPTION------------------{docker_image_name}')
-            logger.warning(e.output.decode())
+                logger=logger, stdout=subprocess.PIPE)
+        except subprocess.CalledProcessError:
             return None
 
         yamls = list(r[1] for r in split_yaml_documents(opm_rendered.stdout))
@@ -321,16 +316,13 @@ class BundleVersion:
                 if prop["type"] == "olm.package":
                     actual_version = prop["value"]["version"]
                     if actual_version != expected_version.ver:
-                        logger.info(f'OPM EXCEPTION------------------Skipping malformed image f{docker_image_name} (contains version {actual_version}, expected {expected_version.ver})')
                         logger.warning(f"Skipping malformed image f{docker_image_name} (contains version {actual_version}, expected {expected_version.ver})")
                         return None
                     else:
-                        logger.info(f'OPM OK------------------{expected_version} - {yamls}')
                         return cls(version=expected_version,
                                    yamls=yamls)
 
         failure = f"No `olm.package` property found in {docker_image_name}!"
-        logger.info(f'END LOAD------------------{failure}')
         logger.warning(failure)
         return None
 

--- a/wordpress-operator-olm.yaml
+++ b/wordpress-operator-olm.yaml
@@ -17,7 +17,7 @@ _versions:   # Substituted by `make-catalog.py`
     from: v0.2.0
     to: v0.2.0
   - pattern: quay-its.epfl.ch/svc0041/wordpress-olm-bundle:@@VERSION@@
-    from: v0.2.1
+    from: v0.3.0
 ---
 schema: olm.channel
 name: test

--- a/wordpress-operator-olm.yaml
+++ b/wordpress-operator-olm.yaml
@@ -15,6 +15,9 @@ _versions:   # Substituted by `make-catalog.py`
     to: v0.1.16
   - pattern: anonymous.apps.t-ocp-its-01.xaas.epfl.ch/svc0041/wordpress-olm-bundle:@@VERSION@@
     from: v0.2.0
+    to: v0.2.0
+  - pattern: quay-its.epfl.ch/svc0041/wordpress-olm-bundle:@@VERSION@@
+    from: v0.2.1
 ---
 schema: olm.channel
 name: test


### PR DESCRIPTION
- A pull secret has been added to build the catalog.
- For non anonymous pull, `opm render` also needs a secret in an inflexible location, `/root/.docker/config.json`.